### PR TITLE
Fix error in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,12 +64,14 @@ For 4.7.1 version use [0.0.8 tag](https://github.com/Nks/orchid-repeater-field/t
 1. Simply start adding the `RepeaterField::make('repeater')` in your screen:
     Example:
     ```php
-        public function fields(): array
+        public function layout(): array
         {
             return [
-                RepeaterField::make('repeater')
-                    ->title('Repeater')
-                    ->layout(App\Http\Orchid\Layouts\Repeaters\RepeaterFields::class),
+                Layout::rows([
+                    RepeaterField::make('repeater')
+                        ->title('Repeater')
+                        ->layout(App\Http\Orchid\Layouts\Repeaters\RepeaterFields::class),
+                ])
             ];
         }
     ```


### PR DESCRIPTION
We cant use filed in screen, without row.

Becouse we can receiver error:

`Argument 1 passed to Orchid\Screen\Layouts\Base::checkPermission() must be an instance of Orchid\Screen\Layouts\Base, instance of Nakukryskin\OrchidRepeaterField\Fields\Repeater given, called in /Users/ostap/crm/platform/src/Screen/Layouts/Base.php on line 154 (View: /Users/ostap/crm/platform/resources/views/layouts/base.blade.php)
`

## Proposed Changes

  - Fix error