### PR TITLE
Update Repeater.php

### DIFF
--- a/src/Fields/Repeater.php
+++ b/src/Fields/Repeater.php
@@ -66,10 +66,10 @@ class Repeater extends Field
     ];
 
     /**
-     * @param  string  $layout
+     * @param Orchid\Screen\Layouts\Rows $layout
      * @return self
      */
-    public function layout(string $layout): self
+    public function layout($layout): self
     {
         if (! class_exists($layout) && ! (app($layout) instanceof Rows)) {
             throw new \InvalidArgumentException(


### PR DESCRIPTION
Fix wrong parameter type.

The instructions in the readme and the code inside the function is checking for an instance of Rows but the param to the function is accepting only a string

Fixes #
Wrong param type for the function

## Proposed Changes
Change param type to Orchid\Screen\Layouts\Rows
  -
  -
  -