### PR TITLE
[FIX] Updated addPublicDirectory and orchid_mix

### DIFF
--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -104,12 +104,14 @@ class ServiceProvider extends BaseServiceProvider
      */
     private function registerResources(): self
     {
-        $this->dashboard->addPublicDirectory('repeater', ORCHID_REPEATER_FIELD_PACKAGE_PATH.'/public/');
-
+        $this->publishes([
+            ORCHID_REPEATER_FIELD_PACKAGE_PATH . '/public' => public_path('vendor/repeater'),
+        ], 'public');
+        
         View::composer('platform::app', function () {
             $this->dashboard
-                ->registerResource('scripts', orchid_mix('/js/repeater.js', 'repeater'))
-                ->registerResource('stylesheets', orchid_mix('/css/repeater.css', 'repeater'));
+                ->registerResource('scripts', mix('/js/repeater.js', 'vendor/repeater'))
+                ->registerResource('stylesheets', mix('/css/repeater.css', 'vendor/repeater'));
         });
 
         return $this;


### PR DESCRIPTION
## Fixes
As the method addPublicDirectory doesn't exist anymore on Laravel 9.x, I replaced it with publishes method.
Same for orchid_mix that is replaced with mix.
After the installation, user should use php artisan vendor:publish --tag=public --force to publish files

## Proposed Changes
- Replaced addPublicDirectory by publishes
- Replaced orchid_mix by mix